### PR TITLE
Feat/album list show all

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/AlexKMarshall/spotify-clone/branch/master/graph/badge.svg)](https://codecov.io/gh/AlexKMarshall/spotify-clone)
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^16.13.1",
     "react-query": "^2.20.0",
     "react-scripts": "3.4.0",
+    "resize-observer-polyfill": "^1.5.1",
     "tailwindcss": "^1.8.10",
     "typescript": "^4.0.2"
   },

--- a/src/components/AlbumList.tsx
+++ b/src/components/AlbumList.tsx
@@ -1,26 +1,48 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Album } from '../types/Album';
 import { Artist } from '../types/Artist';
+import { useResizeObserver } from '../utils/hooks';
 
 type PropTypes = {
   heading: string;
   albums: Album[];
 };
 
+const useGridColumnCount = (gridRef: React.RefObject<HTMLDivElement>) => {
+  // This will only work for changing the size of the grid and the content
+  // not changing. If children are added and removed, this won't update
+
+  const { width } = useResizeObserver(gridRef);
+  const [colCount, setColCount] = useState(0);
+
+  useEffect(() => {
+    if (gridRef.current) {
+      const gtlStyle = window.getComputedStyle(gridRef.current).gridTemplateColumns;
+      setColCount(gtlStyle.split(' ').length);
+    }
+  }, [gridRef, width]);
+
+  return colCount;
+};
+
 const AlbumList = ({ heading, albums }: PropTypes) => {
+  const gridEl = useRef<HTMLDivElement>(null);
+  const gridColumnCount = useGridColumnCount(gridEl);
+  const albumCount = albums.length;
+  const isMoreToShow = albumCount > gridColumnCount;
+
   return (
     <section className="mt-6">
       <header className="flex items-center justify-between">
         <a href="/">
           <h2 className="text-2xl font-bold text-white hover:underline">{heading}</h2>
         </a>
-        <a href="/" className="text-xs font-bold tracking-wider uppercase hover:underline">
-          See All
-        </a>
+        {isMoreToShow ? <SeeAllLink /> : null}
       </header>
       <div
         className="grid grid-rows-1 mt-3 overflow-y-hidden gap-x-3 grid-cols-album-cards"
         style={{ gridAutoRows: '0px' }}
+        ref={gridEl}
       >
         {albums.map((album) => (
           <AlbumCard key={album.id} {...album} />
@@ -60,6 +82,12 @@ const AlbumCard = ({ id: albumId, name, images, artists }: Album) => (
 const ArtistLink = ({ artist }: { artist: Artist }) => (
   <a href="/" className="text-xs hover:underline">
     {artist.name}
+  </a>
+);
+
+const SeeAllLink = () => (
+  <a href="/" className="text-xs font-bold tracking-wider uppercase hover:underline">
+    See All
   </a>
 );
 

--- a/src/components/ContentPane.tsx
+++ b/src/components/ContentPane.tsx
@@ -9,7 +9,7 @@ const ContentPane = () => {
   const { data } = useQuery('new-releases', () => client('browse/new-releases'));
 
   return (
-    <div className="px-8 overflow-y-auto content-spotify">
+    <div className="px-8 pb-6 overflow-y-auto content-spotify">
       {data ? (
         <>
           <AlbumList heading="Shortcuts" albums={data.albums.items} />

--- a/src/components/__tests__/AlbumList.test.tsx
+++ b/src/components/__tests__/AlbumList.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { buildAlbum } from '../../test/generate';
 import { rtlRender, screen } from '../../test/test-utils';
 import { randBetween } from '../../utils/random';
+import faker from 'faker';
 import AlbumList from '../AlbumList';
 
 it('should render list of albums cards with heading', () => {
@@ -20,4 +21,28 @@ it('should render list of albums cards with heading', () => {
       expect(screen.getByRole('link', { name: artist.name })).toBeInTheDocument();
     });
   });
+});
+
+it('should not render a see all link if all albums already displayed', () => {
+  const albums = [buildAlbum()];
+  const heading = faker.lorem.words(2);
+
+  const normalSizeWrapper: React.FC = ({ children }) => <div style={{ width: '1000px' }}>{children}</div>;
+
+  rtlRender(<AlbumList albums={albums} heading={heading} />, { wrapper: normalSizeWrapper });
+
+  expect(screen.queryByRole('link', { name: /see all/i })).not.toBeInTheDocument();
+});
+
+it('should render a see all link if there are more albums than fit on screen', () => {
+  const albums = Array(10)
+    .fill(0)
+    .map(() => buildAlbum());
+  const heading = faker.lorem.words(2);
+
+  const normalSizeWrapper: React.FC = ({ children }) => <div style={{ width: '1000px' }}>{children}</div>;
+
+  rtlRender(<AlbumList albums={albums} heading={heading} />, { wrapper: normalSizeWrapper });
+
+  expect(screen.getByRole('link', { name: /see all/i })).toBeInTheDocument();
 });

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
 
-// Need to make this more generic and take any number of arguments
 const useSafeDispatch = <A>(dispatch: React.Dispatch<A>) => {
   const mounted = React.useRef(false);
   React.useLayoutEffect(() => {
@@ -80,4 +80,29 @@ const useAsync = (initialState?: State) => {
   };
 };
 
-export { useAsync };
+type ContentRect = Pick<DOMRectReadOnly, 'width' | 'height' | 'top' | 'right' | 'bottom' | 'left'>;
+
+const useResizeObserver = (resizeSubject: React.RefObject<HTMLDivElement>) => {
+  const emptyRect = { width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0 };
+  const [contentRect, setContentRect] = useState<ContentRect>(emptyRect);
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver((entries) => {
+      setContentRect(entries[0].contentRect);
+    });
+
+    if (resizeSubject.current) {
+      resizeObserver.observe(resizeSubject.current);
+    }
+
+    return () => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
+  }, [resizeSubject]);
+
+  return contentRect;
+};
+
+export { useAsync, useResizeObserver };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9621,6 +9621,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
This PR changes the See All link on the album lists to only render if there are more albums than currently displayed.

It creates a custom hook useResizeObserver which allows you to watch for changes in the dimensions of a div.

The album list grid currently works by auto-fitting as many columns as it can. Then it wraps into a zero-height additional row(s). So only the first row is actually visibile. 

We can run getComputedStyle on the grid container, and getting the computed value of the gridTemplateColumns. This is a space separated string of pixel values. So if we split on " ", then we can get the total columns in the grid.

We can do this in a useEffect, and trigger that based on the width that is output by the useResizeObserver hook. That way, if the user changes the size of the screen, the columns will be re-counted.